### PR TITLE
feat(markov): BOT_FRIENDS allowlist — kiválasztott botok beszélgethetnek a ruinBottal

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -8,3 +8,6 @@ MORNING_MINUTE=0
 # optional
 SPECIAL_DATE=
 SPECIAL_ADJECTIVE=
+# optional: comma-separated bot user IDs that may talk to the bot
+# (mention/reply triggers a markov reply WITH ping; other bots stay ignored)
+BOT_FRIENDS=

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Meghivod sajat szerverre
 .envbe beirod a tokent meg egy channel idt ahova irja h na re az .env-example alapján  
 Requirementset felrakod  
 Elinditod a main.py-t 
+bot-baratok (opcionalis):  
+.env-be BOT_FRIENDS=<bot user id, vesszovel tobbet> — az itt felsorolt botok taggelhetik/replyzhetik a ruinbotot es valaszt kapnak (pinggel), minden mas bot tovabbra is ignoralva. A bot-barat szovegebol NEM tanul a markov.

--- a/cogs/markov.py
+++ b/cogs/markov.py
@@ -35,6 +35,14 @@ class Markov(commands.Cog):
         self.text_model = {}
         self.bot = bot
 
+        # BOT_FRIENDS: comma-separated bot user IDs that are allowed to talk
+        # to us. Every other bot stays ignored (no accidental loops with
+        # random bots). Example: BOT_FRIENDS=1498350417074196621
+        self.bot_friends = {
+            int(x) for x in os.getenv("BOT_FRIENDS", "").replace(" ", "").split(",")
+            if x.isdigit()
+        }
+
         if not os.path.exists(f"usr/markov/"):
             os.mkdir(f"usr/markov/")
         try:
@@ -48,7 +56,23 @@ class Markov(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        if message.author.bot or not message.content or message.guild is None:
+        if not message.content or message.guild is None:
+            return
+        if message.author.bot:
+            # Bot-authored messages: only configured bot friends get through,
+            # they can only TRIGGER a reply (mention or reply-to-us), and we
+            # never learn their text into the markov corpus — that would let
+            # two bots echo-train each other.
+            if message.author.id not in self.bot_friends:
+                return
+            mentioned = f"<@{self.bot.user.id}>" in message.content
+            replied_to_us = False
+            if message.type == discord.MessageType.reply and message.reference:
+                reference = await message.channel.fetch_message(
+                    message.reference.message_id)
+                replied_to_us = reference.author.id == self.bot.user.id
+            if mentioned or replied_to_us:
+                await self.markov(message)
             return
         if not os.path.exists(f"usr/markov//{message.guild.id}/"):
             os.mkdir(f"usr/markov//{message.guild.id}/")
@@ -153,7 +177,12 @@ class Markov(commands.Cog):
                 else:
                     sentence = random.choice(urls).strip()
 
-            await ctx.reply(sentence if sentence else "MIT MOND?")
+            # Replying to a bot friend must actually PING it (reply pings are
+            # off by default and main.py suppresses user mentions globally) —
+            # mention-gated bots can't see our reply otherwise. Humans keep
+            # the current no-ping behaviour.
+            await ctx.reply(sentence if sentence else "MIT MOND?",
+                            mention_author=getattr(ctx.author, "bot", False))
         except Exception as e:
             print(f"baj van: {e}")
             await ctx.send(f"baj van: {e}")


### PR DESCRIPTION
## Mit csinál

A mostani `author.bot` szűrő minden bot-üzenetet eldob, így két bot soha nem tud beszélgetni. Ez a PR egy **opt-in** kiskaput ad, ami minden másra megtartja a hurok-védelmet:

- **`BOT_FRIENDS` env** (vesszővel elválasztott bot user ID-k): csak a felsorolt botok jutnak át a szűrőn, minden más bot ugyanúgy ignorálva marad. Üresen hagyva / kihagyva = pontosan a jelenlegi viselkedés, semmi nem változik.
- A bot-barát üzenete **csak triggerelhet** (mention vagy reply a ruinbot üzenetére) — a szövege **nem kerül be a markov-korpuszba**, tehát két bot nem tudja egymást visszhang-tanítani.
- Bot-barátnak a válasz **`mention_author=True`-val** megy (a reply-ping alapból ki van kapcsolva, és a `main.py` globálisan tiltja a user-mentionöket) — a mention-kapuzott botok különben nem látnák meg a választ. Embereknek marad a jelenlegi ping-mentes viselkedés.

## Miért

Szeretnénk a guildben az ImbulClaw (OpenClaw LLM-bot) ↔ ruinBot beszélgetést. Az ImbulClaw oldala már kész (csak az őt mention-ölő bot-üzenetekre reagál + saját sliding-window hurok-védelme van: max 20 üzenetváltás/60 mp botpáronként, utána cooldown), de a ruinBot a bot-szerzőjű üzeneteket még a feldolgozás előtt eldobja.

## Használat

`.env`-be:
```
BOT_FRIENDS=1498350417074196621
```
(ez az ImbulClaw ID-ja — több bot vesszővel sorolható)

## Tesztelés

- `ast.parse` syntax-check OK
- Hurok-megfontolás: a markov-válasz determinisztikusan 1 üzenet/trigger, a korpusz-tanulás bot-szövegből kizárva; a túloldali LLM-bot rate-limitje (1-3 perc/válasz) + saját loop-guardja zárja a kört